### PR TITLE
ci: improve event triggers 🥳

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -1,4 +1,8 @@
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
- Don't run CI checks on every push anymore. This makes it less annoying to push "work in progress" commits.
- Do run CI checks on every push to the main branch.
- Run CI checks on pull requests.

Documentation of the `pull_request` event trigger for reference: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request