### PR TITLE
ci: improve event triggers

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -1,4 +1,8 @@
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always

--- a/devel/scripts/check_commit_message.sh
+++ b/devel/scripts/check_commit_message.sh
@@ -1,15 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Documentation of default environment variables in GitHub actions:
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+#
+if test "$GITHUB_EVENT_NAME" = "pull_request"
+then
+    # We're running in CI against a "pull_request" event, where GitHub creates
+    # a weird merge commit that git is pointing to. Determine which commit we
+    # actually need to check first.
+    git fetch # otherwise name of branch won't be recognized
+    commit_to_check="origin/$GITHUB_HEAD_REF"
+else
+    # We're either not running in CI at all or on a "push" event.
+    # The git HEAD is already pointing at the right thing.
+    commit_to_check="$(git rev-parse HEAD)"
+fi
+
 echo "Checking commit message for 🥳 emoji..."
-if ! git log -1 --pretty=%B | grep -qE "(:partying_face:|🥳)"
+if ! git log -1 --pretty=%B "$commit_to_check" | grep -qE "(:partying_face:|🥳)"
 then
     echo "Please be more joyful !! 🥳"
     exit 1
 fi
 
 echo "Checking commit message subject length..."
-if (( "$(git log -1 --pretty=%s | wc -c)" > 50 ))
+if (( "$(git log -1 --pretty=%s "$commit_to_check" | wc -c)" > 50 ))
 then
     echo "Please avoid lengthy commit message subjects!"
     echo "https://cbea.ms/git-commit/#limit-50"


### PR DESCRIPTION
- Don't run CI checks on every push anymore. This makes it less annoying to push "work in progress" commits.
- Do run CI checks on every push to the main branch.
- Run CI checks on pull requests.

Documentation of the `pull_request` event trigger for reference: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request